### PR TITLE
Fix WooCommerce search returning wrong products

### DIFF
--- a/lookup.py
+++ b/lookup.py
@@ -19,12 +19,14 @@ def _fetch_json(url: str) -> dict | list | None:
         return None
 
 
-def _fetch_html(url: str) -> str | None:
-    """Fetch a URL and return raw HTML."""
+def _fetch_html(url: str) -> tuple[str, str] | None:
+    """Fetch a URL and return (final_url, html) tuple."""
     try:
         req = Request(url, headers={"User-Agent": "CoffeeTracker/1.0"})
         with urlopen(req, timeout=10) as resp:
-            return resp.read().decode("utf-8", errors="replace")
+            final_url = resp.url
+            html = resp.read().decode("utf-8", errors="replace")
+            return (final_url, html)
     except Exception:
         return None
 
@@ -203,17 +205,28 @@ class ShopifySearcher(CoffeeSearcher):
 
 # ── WooCommerce Searcher ───────────────────────────────────────────────────
 
+_PRODUCT_TITLE_CLASSES = {
+    "jet-woo-builder-archive-product-title",
+    "woocommerce-loop-product__title",
+    "woocommerce-LoopProduct-link",
+}
+
+
 class _LinkExtractor(HTMLParser):
-    """Extract product links from WooCommerce search results."""
+    """Extract product links from WooCommerce search result title elements only."""
     def __init__(self):
         super().__init__()
         self.links: list[tuple[str, str]] = []  # (url, text)
+        self._in_title_container = 0
         self._current_link = None
         self._current_text = ""
 
     def handle_starttag(self, tag, attrs):
-        if tag == "a":
-            attrs_dict = dict(attrs)
+        attrs_dict = dict(attrs)
+        classes = set(attrs_dict.get("class", "").split())
+        if classes & _PRODUCT_TITLE_CLASSES:
+            self._in_title_container += 1
+        if tag == "a" and self._in_title_container > 0:
             href = attrs_dict.get("href", "")
             if "/product/" in href:
                 self._current_link = href
@@ -227,6 +240,8 @@ class _LinkExtractor(HTMLParser):
         if tag == "a" and self._current_link:
             self.links.append((self._current_link, self._current_text.strip()))
             self._current_link = None
+        if self._in_title_container > 0 and tag in ("div", "h2", "h3", "a", "span"):
+            self._in_title_container -= 1
 
 
 class _JsonLdExtractor(HTMLParser):
@@ -264,9 +279,13 @@ class WooCommerceSearcher(CoffeeSearcher):
     def search(self, coffee_name: str) -> str | None:
         """Search WooCommerce and return the best matching product URL."""
         url = f"{self.base_url}/?s={quote_plus(coffee_name)}&post_type=product"
-        html = _fetch_html(url)
-        if not html:
+        result = _fetch_html(url)
+        if not result:
             return None
+        final_url, html = result
+        # WooCommerce redirects single-result searches to the product page
+        if "/product/" in final_url:
+            return final_url
         extractor = _LinkExtractor()
         extractor.feed(html)
         if not extractor.links:
@@ -279,13 +298,16 @@ class WooCommerceSearcher(CoffeeSearcher):
             if ratio > best_ratio:
                 best_ratio = ratio
                 best_url = link_url
+        if best_ratio < 0.3:
+            return None
         return best_url
 
     def fetch_product(self, product_url: str) -> dict | None:
         """Fetch a product page and extract JSON-LD Product entity."""
-        html = _fetch_html(product_url)
-        if not html:
+        result = _fetch_html(product_url)
+        if not result:
             return None
+        _, html = result
         extractor = _JsonLdExtractor()
         extractor.feed(html)
 

--- a/openspec/changes/archive/2026-03-10-fix-woocommerce-search/.openspec.yaml
+++ b/openspec/changes/archive/2026-03-10-fix-woocommerce-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-03-10

--- a/openspec/changes/archive/2026-03-10-fix-woocommerce-search/design.md
+++ b/openspec/changes/archive/2026-03-10-fix-woocommerce-search/design.md
@@ -1,0 +1,42 @@
+## Context
+
+The `WooCommerceSearcher.search()` uses Python's `urlopen` which follows redirects transparently. When WooCommerce has a single search result, it 302-redirects to the product page. The code then parses the product page with `_LinkExtractor`, which picks up sidebar/related product links instead of the actual product.
+
+On multi-result pages, the search results use Jet WooCommerce Builder with `jet-woo-builder-archive-product-title` class for product titles, not plain `<a>` tags with `/product/` in href.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Handle single-result redirects (detect redirect URL is a product page)
+- Fix multi-result extraction to only target search result product titles
+- Add minimum similarity threshold to reject garbage matches
+
+**Non-Goals:**
+- Changing the Shopify searcher
+- Changing the base class interface
+
+## Decisions
+
+### 1. Detect single-result redirect via response URL
+
+Use `urlopen` response's `.url` attribute to check if we were redirected to a product page. If the final URL contains `/product/`, that IS our result — return it directly without link extraction.
+
+**Why**: This is how WooCommerce handles single-result searches. The redirect URL is the correct answer.
+
+### 2. Fix `_LinkExtractor` for multi-result pages
+
+Gringo uses Jet WooCommerce Builder. Search result titles are in elements with class `jet-woo-builder-archive-product-title`. Only extract links from within these title elements.
+
+However, since other WooCommerce sites may use standard WooCommerce markup (class `woocommerce-loop-product__title` or `woocommerce-LoopProduct-link`), we should check for both Jet-style and standard WooCommerce patterns.
+
+**Approach**: Track whether we're inside a known product title container and only capture links from those containers.
+
+### 3. Add similarity threshold of 0.3
+
+Reject matches below 0.3 ratio. The current bug had a 0.28 match being accepted. A 0.3 threshold is low enough to allow partial matches but high enough to reject random noise.
+
+**Why**: Even with better link extraction, a threshold prevents returning confidently wrong results.
+
+## Risks / Trade-offs
+
+- **[Jet WooBuilder-specific parsing]** → If a future WooCommerce roaster uses different markup, extraction may fail. Mitigation: falls back to returning None (no wrong data), and the `_LinkExtractor` can be extended with new class patterns.

--- a/openspec/changes/archive/2026-03-10-fix-woocommerce-search/proposal.md
+++ b/openspec/changes/archive/2026-03-10-fix-woocommerce-search/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+WooCommerce lookup returns wrong products. Searching "Purple Pacamara" on Gringo Nordic returns a Sumatra coffee (wrong country, wrong price) instead of the correct El Salvador Purple Pacamara. Root cause: `_LinkExtractor` captures all `/product/` links on the page (footer, sidebar, related products) rather than just search result entries, and there's no minimum similarity threshold so garbage matches (0.28 ratio) are accepted.
+
+## What Changes
+
+- Fix `_LinkExtractor` to only capture product links from the WooCommerce search results section (look for `.woocommerce-loop-product__link` or equivalent WooCommerce-specific product card markup)
+- Add a minimum similarity threshold (~0.4) to `WooCommerceSearcher.search()` so low-confidence matches are rejected rather than returning wrong data
+- Verify the fix works against the Gringo Nordic site with "Purple Pacamara" query
+
+## Capabilities
+
+### New Capabilities
+
+_(none)_
+
+### Modified Capabilities
+
+- `roastery-lookup`: WooCommerce search result extraction is more precise and rejects low-confidence matches
+
+## Impact
+
+- **`lookup.py`**: Fix `_LinkExtractor` and add similarity threshold in `WooCommerceSearcher.search()`
+- No API, frontend, or dependency changes

--- a/openspec/changes/archive/2026-03-10-fix-woocommerce-search/specs/roastery-lookup/spec.md
+++ b/openspec/changes/archive/2026-03-10-fix-woocommerce-search/specs/roastery-lookup/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: WooCommerce provider extracts data from JSON-LD
+The WooCommerce provider (renamed `WooCommerceSearcher`) SHALL be configured with a `base_url` and a `field_map` dict that maps site-specific JSON-LD `additionalProperty` names to CoffeeBean field names. It SHALL search using the WooCommerce search URL pattern (`/?s={query}&post_type=product`), find the best matching product page, fetch it, and extract data from JSON-LD `application/ld+json` script tags.
+
+The provider SHALL parse the Product entity's `additionalProperty` array and map values using the configured `field_map`. Fields not in the map SHALL be ignored. The provider SHALL NOT use any LLM or external AI service.
+
+When searching, the provider SHALL handle the case where WooCommerce redirects a single-result search directly to the product page. If the response URL contains `/product/`, the provider SHALL use that URL directly as the matched product.
+
+When extracting product links from multi-result search pages, the provider SHALL only consider links within known WooCommerce product title elements (e.g., elements with class `jet-woo-builder-archive-product-title` or `woocommerce-loop-product__title`), not sidebar, footer, or related product links.
+
+The provider SHALL reject search matches where the title similarity ratio is below 0.3.
+
+#### Scenario: Single search result redirects to product page
+- **WHEN** a WooCommerce search for "Purple Pacamara" returns a redirect to `/product/el-salvador-purple-pacamara-2/`
+- **THEN** the provider SHALL use that redirected URL as the matched product
+
+#### Scenario: Multi-result search picks best match
+- **WHEN** a WooCommerce search returns multiple product results
+- **THEN** the provider SHALL only consider product links within search result title elements, not sidebar or footer links
+
+#### Scenario: Low similarity match rejected
+- **WHEN** the best matching product title has a similarity ratio below 0.3
+- **THEN** the provider SHALL return None (no match) rather than the low-confidence result
+
+#### Scenario: Gringo Nordic field mapping
+- **WHEN** the provider is configured with `field_map: {"land": "country_grown", "art-varietet": "bean_type", "processmetod": "process"}` and fetches a page with those JSON-LD properties
+- **THEN** the returned dict SHALL contain CoffeeBean-named fields with the values from JSON-LD
+
+#### Scenario: Partial data on product page
+- **WHEN** the provider fetches a product page where some `additionalProperty` entries are missing
+- **THEN** the returned dict SHALL contain only the fields that were present, with missing fields omitted
+
+#### Scenario: Product name cleaned of roastery suffix
+- **WHEN** the JSON-LD product name is "Peru Nueva Florida - Gringo Nordic Coffee Roaster"
+- **THEN** the returned `name` field SHALL be "Peru Nueva Florida" (suffix removed)
+
+#### Scenario: WooCommerce search returns multiple results
+- **WHEN** the search returns multiple product links
+- **THEN** the provider SHALL select the product whose name best matches the search query

--- a/openspec/changes/archive/2026-03-10-fix-woocommerce-search/tasks.md
+++ b/openspec/changes/archive/2026-03-10-fix-woocommerce-search/tasks.md
@@ -1,0 +1,15 @@
+## 1. Handle single-result redirect
+
+- [x] 1.1 Modify `WooCommerceSearcher.search()` to use `urlopen` response URL — if the final URL contains `/product/`, return it directly as the match (WooCommerce single-result redirect)
+
+## 2. Fix multi-result link extraction
+
+- [x] 2.1 Rewrite `_LinkExtractor` to only capture links within WooCommerce product title elements (class `jet-woo-builder-archive-product-title` or `woocommerce-loop-product__title`), ignoring sidebar/footer/related product links
+
+## 3. Add similarity threshold
+
+- [x] 3.1 Add minimum similarity threshold of 0.3 in `WooCommerceSearcher.search()` — return None if best match ratio is below threshold
+
+## 4. Verification
+
+- [x] 4.1 Test "Purple Pacamara" lookup against Gringo Nordic — should return El Salvador, 169 SEK

--- a/openspec/specs/roastery-lookup/spec.md
+++ b/openspec/specs/roastery-lookup/spec.md
@@ -92,6 +92,24 @@ The WooCommerce provider (renamed `WooCommerceSearcher`) SHALL be configured wit
 
 The provider SHALL parse the Product entity's `additionalProperty` array and map values using the configured `field_map`. Fields not in the map SHALL be ignored. The provider SHALL NOT use any LLM or external AI service.
 
+When searching, the provider SHALL handle the case where WooCommerce redirects a single-result search directly to the product page. If the response URL contains `/product/`, the provider SHALL use that URL directly as the matched product.
+
+When extracting product links from multi-result search pages, the provider SHALL only consider links within known WooCommerce product title elements (e.g., elements with class `jet-woo-builder-archive-product-title` or `woocommerce-loop-product__title`), not sidebar, footer, or related product links.
+
+The provider SHALL reject search matches where the title similarity ratio is below 0.3.
+
+#### Scenario: Single search result redirects to product page
+- **WHEN** a WooCommerce search for "Purple Pacamara" returns a redirect to `/product/el-salvador-purple-pacamara-2/`
+- **THEN** the provider SHALL use that redirected URL as the matched product
+
+#### Scenario: Multi-result search picks best match
+- **WHEN** a WooCommerce search returns multiple product results
+- **THEN** the provider SHALL only consider product links within search result title elements, not sidebar or footer links
+
+#### Scenario: Low similarity match rejected
+- **WHEN** the best matching product title has a similarity ratio below 0.3
+- **THEN** the provider SHALL return None (no match) rather than the low-confidence result
+
 #### Scenario: Gringo Nordic field mapping
 - **WHEN** the provider is configured with `field_map: {"land": "country_grown", "art-varietet": "bean_type", "processmetod": "process"}` and fetches a page with those JSON-LD properties
 - **THEN** the returned dict SHALL contain CoffeeBean-named fields with the values from JSON-LD


### PR DESCRIPTION
## Summary
- Detect WooCommerce single-result redirects by checking if the response URL contains `/product/`, returning it directly instead of parsing as a search results page
- Scope `_LinkExtractor` to only capture links within product title elements (`jet-woo-builder-archive-product-title`, `woocommerce-loop-product__title`), ignoring sidebar/footer/related product links
- Add minimum similarity threshold of 0.3 to reject low-confidence matches

## Test plan
- [x] "Purple Pacamara" lookup against Gringo Nordic returns El Salvador, 169 SEK (previously returned Indonesia, 139 SEK)
- [ ] Verify multi-result WooCommerce searches still work (e.g. broader queries)
- [ ] Verify Shopify providers (Morgon, Kafferäven) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)